### PR TITLE
Change the die type for the ship encounter table.

### DIFF
--- a/Halberds and Helmets/Raising a God/Raising-a-God.tex
+++ b/Halberds and Helmets/Raising a God/Raising-a-God.tex
@@ -214,7 +214,7 @@ Roll once per day.
 
 \begin{center}
 \begin{tabular}{cl}
-\tableheader[b]{1d6 & Ship Encounter}
+\tableheader[b]{1d10 & Ship Encounter}
 1 & \hyperref[sec:monkeyman-caravel]{monkeyman caravel}, see p.~\pageref{sec:monkeyman-caravel} \\
 2 & \hyperref[sec:squidman-nautilus]{squidman nautilus}, see p.~\pageref{sec:squidman-nautilus} \\
 3 & \hyperref[sec:eelman-centipede]{eelman centipede}, see p.~\pageref{sec:eelman-centipede}    \\


### PR DESCRIPTION
Raising-a-God.tex listed a d6 in the header for the ship encounter, but there were ten options.  If the intent is to have +modifiers to the die roll, that may have be correct, but this commit changes the header to indicate a d10.
